### PR TITLE
Remove unneeded yarn, fix npm instruction

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,12 +8,11 @@ ARG NODE_VERSION=14.6.0
 RUN curl https://raw.githubusercontent.com/creationix/nvm/v0.38.0/install.sh | bash
 RUN . $NVM_DIR/nvm.sh && nvm install $NODE_VERSION --latest-npm
 ENV PATH $NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
-RUN npm install -g yarn
 
 WORKDIR /app
 
 ADD ./package.json ./package.json
 ADD ./package-lock.json ./package-lock.json
-RUN npm install
+RUN npm ci
 
 ADD . .


### PR DESCRIPTION
Using npm ci will reuse package-lock.json to resolve dependencies, so it's a lot faster and more likely to be consistent across environments